### PR TITLE
Update keyfeatures.css

### DIFF
--- a/assets/theme-css/keyfeatures.css
+++ b/assets/theme-css/keyfeatures.css
@@ -31,7 +31,7 @@
 .keyfeatures-box-text {
   line-height: 1.5;
   margin: 15px;
-  height: 6em;
+  height: auto;
   overflow: hidden;
 }
 


### PR DESCRIPTION
Changed the height of .keyfeatures-box-text from a fixed 6em to auto to accomodate longer texts. The box height now depends on the longest text in each row.